### PR TITLE
packagegroup-tn-tools: thermal-imx-test requires either x11 or wayland

### DIFF
--- a/recipes-core/packagegroups/packagegroup-tn-tools.bb
+++ b/recipes-core/packagegroups/packagegroup-tn-tools.bb
@@ -28,7 +28,9 @@ RDEPENDS_${PN} = " \
     libgpiod \
     stress-ng \
     cpulimit \
-    ${@bb.utils.contains('DISTRO', 'b2qt', '', 'thermal-imx-test', d)} \
+    ${@bb.utils.contains('DISTRO', 'b2qt', '', \
+       bb.utils.contains('DISTRO_FEATURES', 'x11', 'thermal-imx-test', \
+       bb.utils.contains('DISTRO_FEATURES', 'wayland', 'thermal-imx-test', '',d), d), d)} \
 "
 
 RDEPENDS_${PN}_append_mx7 = " voicehat-test"


### PR DESCRIPTION
thermal-imx-test depends on glmark2 which in turn requires either the
x11 or wayland backend to be available in DISTRO_FEATURES. This is not
the case for fb based distrois like fsl-imx-fb.

Fixes #3 