### PR TITLE
kernel-module-imx-gpu-viv: add source branch to kernel source

### DIFF
--- a/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_%.bbappend
+++ b/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_%.bbappend
@@ -3,7 +3,7 @@
 # Copyright 2017-2021 NXP
 # Released under the MIT license (see COPYING.MIT for the terms)
 
-SRCBRANCH = "tn-imx_5.15.5_1.0.0-next"
+SRCBRANCH = "tn-imx_5.15.71_2.2.0-next"
 LOCALVERSION = "${@'-%s' % '-'.join(d.getVar('SRCBRANCH', True).split('_')[2:]).lower()}"
-KERNEL_SRC = "git://github.com/TechNexion/linux-tn-imx.git;protocol=https"
-SRCREV = "539e9f4741b1844f0f23e63a5a4efb48341dd820"
+KERNEL_SRC = "git://github.com/TechNexion/linux-tn-imx.git;protocol=https;branch=${SRCBRANCH}"
+SRCREV = "45d3db9701efcb43fbf06c68fef2a9b4eba9ae3d"


### PR DESCRIPTION
Both potential upstream sources (meta-imx, meta-freescale) expect `KERNEL_SRC` to be complete (with branch specifier if necessary).

---

Related #33 